### PR TITLE
fix predict memory release

### DIFF
--- a/detect/detector.py
+++ b/detect/detector.py
@@ -57,19 +57,27 @@ class Detector(object):
         list of detection results
         """
         num_images = det_iter._size
+        result = []
+        detections = []
         if not isinstance(det_iter, mx.io.PrefetchingIter):
             det_iter = mx.io.PrefetchingIter(det_iter)
         start = timer()
-        detections = self.mod.predict(det_iter).asnumpy()
+        for nbatch, det_batch in enumerate(det_iter):
+            self.mod.forward(det_batch, is_train=False)
+            pad = det_batch.pad
+            outputs = [out[0:out.shape[0]-pad].copy() for out in self.mod.get_outputs()]
+            detections.append(outputs)
         time_elapsed = timer() - start
         if show_timer:
             print("Detection time for {} images: {:.4f} sec".format(
                 num_images, time_elapsed))
-        result = []
-        for i in range(detections.shape[0]):
-            det = detections[i, :, :]
-            res = det[np.where(det[:, 0] >= 0)[0]]
-            result.append(res)
+        for outputs in detections:
+            for output in outputs:
+                output = output.asnumpy()
+                for i in range(output.shape[0]):
+                    det = output[i, :, :]
+                    res = det[np.where(det[:, 0] >= 0)[0]]
+                    result.append(res)
         return result
 
     def im_detect(self, im_list, root_dir=None, extension=None, show_timer=False):


### PR DESCRIPTION
In my test, when I try to infer a lot pictures one time, mx.mod.predict will hold the result in gpu and the memory will increase until all the images are done. So I change mx.mod.predict to mx.mod.forward and make the loop for detection.