### PR TITLE
Update symbol_builder.py

### DIFF
--- a/symbol/symbol_builder.py
+++ b/symbol/symbol_builder.py
@@ -1,4 +1,5 @@
 import mxnet as mx
+import common
 from common import multi_layer_feature, multibox_layer
 
 


### PR DESCRIPTION
Updated to resolve the error:

  File "/home/ec2-user/SageMaker/mxnet-ssd/symbol/symbol_builder.py", line 2, in <module>
    from common import multi_layer_feature, multibox_layer
ModuleNotFoundError: No module named 'common'

The error occurred while running the AWS Sagemaker Local inference notebook - https://aws.amazon.com/blogs/iot/sagemaker-object-detection-greengrass-part-2-of-3/